### PR TITLE
Bugfix attempt for github pages 404 error

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,3 +1,4 @@
 name: Your New Jekyll Site
 markdown: redcarpet
 pygments: true
+baseurl: /simple-documentation-process

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@ title: Your New Jekyll Site
   <h1>Blog Posts</h1>
   <ul class="posts">
     {% for post in site.posts %}
-      <li><span>{{ post.date | date_to_string }}</span> &raquo; <a href="{{ post.url }}">{{ post.title }}</a></li>
+      <li><span>{{ post.date | date_to_string }}</span> &raquo; <a href="{{ site.baseurl }}{{ post.url }}">{{ post.title }}</a></li>
     {% endfor %}
   </ul>
 </div>


### PR DESCRIPTION
When I pushed this jekyll blog to github, the links on the index
page went to 404 messages.

https://github.com/jekyll/jekyll/issues/2182

The fix: adding baseurls to my _config.yaml and all of my links.

A baseurl is like the tent you store all of your personal effects in.
By not having a baseurl, I was telling github that my stuff was scattered
all over my campground.  Because of the way github sets things up,
a tent is more or less connected to a repository.  So when I clicked on the
link
http://tararoys.github.io/jekyll/update/2014/03/30/welcome-to-jekyll.html,
it went looking for a github pages project on my account calle 'jekyll'
a different 'tent.' than the tent called simple-documentation-process.
So my index page was in simple-documentation-process, but the links
told github to look for a different project (a different 'tent') on my account called jekyll,
and since I don't have such a project, it was giving me 404 error pages.

The fix is sort of mentioned in this section of the github documentaion,
http://jekyllrb.com/docs/github-pages/#project_page_url_structure, but I would
not have known to follow that set of instructions debugged it without
the help of a comment from somebody experienced in the issue tracker.

I feel that setting up a jekyll blog on github is a 'common' task. On the
other hand, having spend seven years without github training, it's probably
a lot less commen than I would like to think, and my instict says that
people like me who try to set up a jekyll blog and run into this issue and
don't persist long enough to solve it are a lot more common than people who
throw the issue into the issue tracker.

I wonder how many new users run into this issue and don't ever solve it?
Also, I haven't actually tested this on github paged yet, nad I can't until
I finish this commit message.
